### PR TITLE
Bugfix default node type overrides properly

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,1 @@
+hadoop_type_of_node: slave

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,2 @@
-hadoop_type_of_node: slave
 hadoop_home: /opt/hadoop-1.X
 mirrors: [ "htttp://mirror.cc.columbia.edu/pub/software/apache/hadoop/core/hadoop-1.2.1/", "http://ftp.cixug.es/apache/hadoop/core/hadoop-1.2.1/","http://www-eu.apache.org/dist/hadoop/core/hadoop-1.2.1/","http://ftp.osuosl.org/pub/apache/hadoop/core/hadoop-1.2.1/" ]


### PR DESCRIPTION
when hadoop_type_of_node is set in the vars/main.yml file, it isn't overridden by a hostvar of the same name. Moving this to defaults/main.yml fixes this.